### PR TITLE
Add wage histogram

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -14,7 +14,9 @@ class PaginatedContractSerializer(pagination.PaginationSerializer):
     average = serializers.SerializerMethodField()
     minimum = serializers.SerializerMethodField()
     maximum = serializers.SerializerMethodField()
+
     hourly_wage_stats = serializers.SerializerMethodField()
+    wage_histogram = serializers.SerializerMethodField()
 
     class Meta:
         object_serializer_class = ContractSerializer
@@ -30,3 +32,6 @@ class PaginatedContractSerializer(pagination.PaginationSerializer):
 
     def get_hourly_wage_stats(self, obj):
         return self.context.get('hourly_wage_stats', [])
+
+    def get_wage_histogram(self, obj):
+        return self.context.get('wage_histogram', [])

--- a/api/tests.py
+++ b/api/tests.py
@@ -149,6 +149,15 @@ class ContractsTest(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.data['wage_histogram']), 0)
 
+    def test_histogram_bins(self):
+        resp = self.c.get(self.path, {'histogram': 2})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.data['wage_histogram']), 2)
+        self.assertResultsEqual(resp.data['wage_histogram'], [
+          {'count': 2, 'min': 16.0, 'max': 33.0},
+          {'count': 1, 'min': 33.0, 'max': 50.0}
+        ])
+
     def assertResultsEqual(self, results, expected):
         dict_results = [dict(x) for x in results]
         self.assertEqual(len(results), len(expected))

--- a/api/tests.py
+++ b/api/tests.py
@@ -139,6 +139,16 @@ class ContractsTest(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.data['average'], (16.0 + 18.0 + 50.0) / 3)
 
+    def test_histogram_length(self):
+        resp = self.c.get(self.path, {'histogram': 5})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.data['wage_histogram']), 5)
+
+    def test_histogram_not_numeric(self):
+        resp = self.c.get(self.path, {'histogram': 'x'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.data['wage_histogram']), 0)
+
     def assertResultsEqual(self, results, expected):
         dict_results = [dict(x) for x in results]
         self.assertEqual(len(results), len(expected))

--- a/api/tests.py
+++ b/api/tests.py
@@ -124,6 +124,21 @@ class ContractsTest(TestCase):
            'contractor_site': None,
            'business_size': None}])
 
+    def test_minimum_price_no_args(self):
+        resp = self.c.get(self.path, {})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data['minimum'], 16.0)
+
+    def test_maximum_price_no_args(self):
+        resp = self.c.get(self.path, {})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data['maximum'], 50.0)
+
+    def test_average_price_no_args(self):
+        resp = self.c.get(self.path, {})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data['average'], (16.0 + 18.0 + 50.0) / 3)
+
     def assertResultsEqual(self, results, expected):
         dict_results = [dict(x) for x in results]
         self.assertEqual(len(results), len(expected))

--- a/api/views.py
+++ b/api/views.py
@@ -103,6 +103,11 @@ def get_histogram(values, bins=10):
         })
     return result
 
+def quantize(num, precision=2):
+  if num is None:
+    return None
+  return Decimal(num).quantize(Decimal(10) ** -precision)
+
 class GetRates(APIView):
 
     def get(self, request):
@@ -116,7 +121,7 @@ class GetRates(APIView):
 
         page_stats['minimum'] = contracts_all.aggregate(Min(wage_field))[wage_field + '__min']
         page_stats['maximum'] = contracts_all.aggregate(Max(wage_field))[wage_field + '__max']
-        page_stats['average'] = contracts_all.aggregate(Avg(wage_field))[wage_field + '__avg']
+        page_stats['average'] = quantize(contracts_all.aggregate(Avg(wage_field))[wage_field + '__avg'])
 
         if contracts_all:
             if bins and bins.isnumeric():

--- a/api/views.py
+++ b/api/views.py
@@ -114,6 +114,10 @@ class GetRates(APIView):
         contracts_all = self.get_queryset(request.QUERY_PARAMS, wage_field)
         page_stats = {}
 
+        page_stats['minimum'] = contracts_all.aggregate(Min(wage_field))[wage_field + '__min']
+        page_stats['maximum'] = contracts_all.aggregate(Max(wage_field))[wage_field + '__max']
+        page_stats['average'] = contracts_all.aggregate(Avg(wage_field))[wage_field + '__avg']
+
         if contracts_all:
             if bins and bins.isnumeric():
                 # numpy wants these to be floats, not Decimals

--- a/hourglass_site/static/hourglass_site/style/main.css
+++ b/hourglass_site/static/hourglass_site/style/main.css
@@ -182,3 +182,14 @@ table caption {
         color: #666;
         font-size: .5em;
         margin-left: .5em; }
+
+
+.has-data {
+    -webkit-transition: opacity 0.5s linear;
+       -moz-transition: opacity 0.5s linear;
+            transition: opacity 0.5s linear;
+}
+
+.loading .has-data {
+  opacity: .2;
+}

--- a/hourglass_site/static/hourglass_site/style/main.css
+++ b/hourglass_site/static/hourglass_site/style/main.css
@@ -184,6 +184,7 @@ table caption {
         margin-left: .5em; }
 
 
+.loading-indicator,
 .has-data {
     -webkit-transition: opacity 0.5s linear;
        -moz-transition: opacity 0.5s linear;
@@ -193,3 +194,13 @@ table caption {
 .loading .has-data {
   opacity: .2;
 }
+
+.loading-indicator {
+  opacity: 0;
+  visibility: hidden;
+}
+
+  .loading .loading-indicator {
+    opacity: 1;
+    visibility: visible;
+  }

--- a/hourglass_site/static/hourglass_site/style/main.css
+++ b/hourglass_site/static/hourglass_site/style/main.css
@@ -200,7 +200,50 @@ table caption {
   visibility: hidden;
 }
 
+  .loading-indicator > * {
+    margin: 0;
+  }
+
   .loading .loading-indicator {
     opacity: 1;
     visibility: visible;
   }
+
+svg {
+  display: block;
+  margin: 0;
+  width: 100%;
+  height: auto;
+}
+
+svg * {
+  vector-effect: non-scaling-stroke;
+}
+
+.axis line,
+.axis path {
+  fill: none;
+  stroke-width: 1;
+  stroke: #000;
+  shape-rendering: crispEdges;
+}
+
+.axis text {
+  font-size: 13px;
+}
+
+.avg .value,
+.axis .tick.primary text {
+  font-weight: bold;
+}
+
+svg.histogram rect {
+  fill: #999;
+  stroke: #fff;
+  stroke-width: 1;
+}
+
+svg.histogram .avg line {
+  stroke-width: 1;
+  stroke: #000;
+}

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -155,7 +155,7 @@
       <div class="graphs six columns">
         <h5>Price Stats</h5>
         <div class="graph">
-          <div id="price-range" class="range-graph">
+          <div id="price-range" class="range-graph has-data">
             <span class="tick min left">
               $<b class="value"></b><br>low
             </span>
@@ -180,26 +180,27 @@
 
     </div><!-- /.row -->
 
+    <table id="results-table" class="results has-data">
+      <caption>
+        <span id="results-total">...</span> matching row(s), showing <span id="results-count">...</span>
+        <a id="export-data" class="button" href="/api/rates/csv/">Export Data</a>
+      </caption>
+      <thead>
+        <tr>
+          <th data-key="labor_category">Labor Category</th>
+          <th data-key="education_level">Minimum Education</th>
+          <th data-key="min_years_experience">Minimum Experience</th>
+          <th data-key="current_price" data-format="$%,.02f">Price</th>
+          <th data-key="idv_piid">Contract #</th>
+          <th data-key="vendor_name">Vendor</th>
+        </tr>
+      </thead>
+      <tbody>
+      </tbody>
+    </table>
+
   </form>
 
-  <table id="results-table" class="results">
-    <caption>
-      <span id="results-total">...</span> matching row(s), showing <span id="results-count">...</span>
-      <a id="export-data" class="button" href="/api/rates/csv/">Export Data</a>
-    </caption>
-    <thead>
-      <tr>
-        <th data-key="labor_category">Labor Category</th>
-        <th data-key="education_level">Minimum Education</th>
-        <th data-key="min_years_experience">Minimum Experience</th>
-        <th data-key="current_price" data-format="$%,.02f">Price</th>
-        <th data-key="idv_piid">Contract #</th>
-        <th data-key="vendor_name">Vendor</th>
-      </tr>
-    </thead>
-    <tbody>
-    </tbody>
-  </table>
 </div>
 
 <script>
@@ -272,7 +273,9 @@
     var data = getFormData();
     console.log("submitting:", data);
 
-    form.classed("loading", true);
+    form
+      .classed("loading", true)
+      .classed("loaded", false);
 
     // cancel the outbound request if there is one
     if (request) request.abort();
@@ -300,6 +303,7 @@
     request = null;
 
     if (error) {
+      form.classed("error", true);
       // ignore aborts
       if (error.statusText === "abort") {
         return;
@@ -310,6 +314,7 @@
     }
 
     console.log("update:", data);
+    form.classed("loaded", true);
 
     d3.select("#results-total")
       .text(data ? formatCommas(data.count) : "(none)");

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -161,6 +161,11 @@
         </div>
 
         <div class="graph">
+
+          <svg id="price-histogram" class="histogram has-data">
+          </svg>
+
+          <!--
           <div id="price-range" class="range-graph has-data">
             <span class="tick min left">
               $<b class="value"></b><br>low
@@ -173,6 +178,7 @@
               $<b class="value"></b>
             </span>
           </div>
+          -->
 
         </div>
 
@@ -228,18 +234,30 @@
   form.on("submit", function onsubmit() {
     // stop the form from submitting
     d3.event.preventDefault();
-    submit();
+    submit(true);
   });
 
-  inputs.on("change", submit);
+  inputs.on("change", function onchange() {
+    submit(true);
+  });
 
   initialize();
 
-  function initialize() {
+  window.addEventListener("popstate", popstate);
+
+  function popstate() {
     // read the query string and set values accordingly
     var data = hourglass.qs.parse(location.search);
+    inputs.on("change", null);
     setFormData(data);
-    submit();
+    inputs.on("change", function onchange() {
+      submit(true);
+    });
+    submit(false);
+  }
+
+  function initialize() {
+    popstate();
 
     var autoCompReq;
     $search.autoComplete({
@@ -277,19 +295,25 @@
     });
   }
 
-  function submit() {
+  var loadingTimeout;
+  function submit(pushState) {
     var data = getFormData();
     console.log("submitting:", data);
 
-    form
-      .classed("loading", true)
-      .classed("loaded", false);
+    form.classed("loaded", false);
+    clearTimeout(loadingTimeout);
+    loadingTimeout = setTimeout(function() {
+      form.classed("loading", true);
+    }, 100);
 
     // cancel the outbound request if there is one
     if (request) request.abort();
+    var defaults = {
+      histogram: 10
+    };
     request = api.get({
       uri: "rates", 
-      data: data
+      data: hourglass.extend(defaults, data)
     }, update);
 
 
@@ -301,12 +325,15 @@
         ].join("?");
       });
 
-    var href = "?" + hourglass.qs.format(data)
-    permalink.attr("href", href);
-    history.pushState(null, null, href);
+    if (pushState) {
+      var href = "?" + hourglass.qs.format(data)
+      permalink.attr("href", href);
+      history.pushState(null, null, href);
+    }
   }
 
   function update(error, data) {
+    clearTimeout(loadingTimeout);
     form.classed("loading", false);
     request = null;
 
@@ -331,18 +358,21 @@
     d3.select("#results-total")
       .text(data ? formatCommas(data.count) : "(none)");
 
-    if (data) {
-      updatePrices(data);
+    if (data && data.results && data.results.length) {
+      updatePriceRange(data);
+      updatePriceHistogram(data);
       // updateHourlyWages(data.hourly_wage_stats, [data.minimum, data.maximum]);
       updateResults(data.results || []);
     } else {
-      updatePrices({minimum: 0, maximum: 1, average: 0});
+      data = EMPTY_DATA;
+      updatePriceRange(EMPTY_DATA);
+      updatePriceHistogram(EMPTY_DATA);
       // updateHourlyWages([], [0, 0]);
       updateResults([]);
     }
   }
 
-  function updatePrices(data) {
+  function updatePriceRange(data) {
     var priceScale = d3.scale.linear()
       .domain([data.minimum, data.maximum])
       .range([0, 100]);
@@ -361,6 +391,158 @@
       selection.select(".value")
         .text(formatPrice(+price));
     }
+  }
+
+  var histogramUpdated = false,
+      EMPTY_DATA = {
+        minimum: 0,
+        maximum: 100,
+        average: 50,
+        wage_histogram: [
+          {count: 0, min: 0, max: 50},
+          {count: 0, min: 50, max: 1}
+        ]
+      };
+  function updatePriceHistogram(data) {
+    var width = 500,
+        height = 200,
+        pad = [30, 15, 50, 45],
+        top = pad[0],
+        left = pad[3],
+        right = width - pad[1],
+        bottom = height - pad[2],
+        svg = d3.select("#price-histogram")
+          .attr("viewBox", [0, 0, width, height].join(" ")),
+        formatDecimal = d3.format(".02f"),
+        formatDollars = function(n) {
+          return "$" + formatDecimal(n);
+        };
+
+    var extent = [data.minimum, data.maximum],
+        bins = data.wage_histogram,
+        x = d3.scale.linear()
+          .domain(extent)
+          .range([left, right]),
+        height = d3.scale.linear()
+          .domain(d3.extent(bins, function(d) { return d.count; }))
+          .range([0, bottom - top]);
+
+    var xAxis = svg.select(".axis.x");
+    if (xAxis.empty()) {
+      xAxis = svg.append("g")
+        .attr("class", "axis x");
+    }
+
+    var yAxis = svg.select(".axis.y");
+    if (yAxis.empty()) {
+      yAxis = svg.append("g")
+        .attr("class", "axis y");
+    }
+
+    var gBar = svg.select("g.bars");
+    if (gBar.empty()) {
+      gBar = svg.append("g")
+        .attr("class", "bars");
+    }
+
+    var avg = svg.select("g.avg");
+    if (avg.empty()) {
+      avg = svg.append("g")
+        .attr("class", "avg");
+      avg.append("text")
+        .attr("text-anchor", "middle")
+        .attr("dy", -10)
+        .html('<tspan class="value"></tspan> average');
+      avg.append("line");
+      avg.append("circle")
+        .attr("cy", -4)
+        .attr("r", 3);
+    }
+
+    avg.select("line")
+      .attr("y1", -4)
+      .attr("y2", bottom - top + 8); // XXX tick size = 6
+    avg.select(".value")
+      .text(formatDollars(data.average));
+
+    var bars = gBar.selectAll(".bar")
+      .data(bins);
+
+    bars.exit().remove();
+
+    var enter = bars.enter().append("g")
+      .attr("class", "bar");
+    enter.append("title");
+
+    var step = (right - left) / bins.length;
+    enter.append("rect")
+      .attr("x", function(d, i) {
+        return left + i * step;
+      })
+      .attr("y", bottom)
+      .attr("width", step)
+      .attr("height", 0);
+
+    bars.select("title")
+      .text(function(d, i) {
+        var inclusive = (i === bins.length - 1),
+            sign = inclusive ? "<=" : "<";
+        return [formatCommas(d.count), ":", formatDollars(d.min), "<= x " + sign, formatDollars(d.max)].join(" ");
+      });
+
+    var t = histogramUpdated
+      ? svg.transition().duration(500)
+      : svg;
+
+    t.select(".avg")
+      .attr("transform", "translate(" + [~~x(data.average), top] + ")");
+
+    t.selectAll(".bar")
+      .each(function(d) {
+        d.x = x(d.min);
+        d.width = x(d.max) - d.x;
+        d.height = height(d.count);
+        d.y = bottom - d.height;
+      })
+      .select("rect")
+        .attr("x", function(d, i) { return d.x; })
+        .attr("y", function(d, i) { return d.y; })
+        .attr("height", function(d, i) { return d.height; })
+        .attr("width", function(d, i) { return d.width; });
+
+    var ticks = bins.map(function(d) { return d.min; })
+      .concat([data.maximum]);
+
+    var xa = d3.svg.axis()
+      .orient("bottom")
+      .scale(x)
+      .tickValues(ticks)
+      .tickFormat(function(d, i) {
+        return (i === 0 || i === bins.length)
+          ? formatDollars(d)
+          : formatDecimal(d);
+      });
+    xAxis.call(xa)
+      .attr("transform", "translate(" + [0, bottom + 2] + ")")
+      .selectAll(".tick")
+        .classed("primary", function(d, i) {
+          return i === 0 || i === bins.length;
+        })
+        .select("text")
+          .attr("text-anchor", "end")
+          .attr("transform", "translate(-20,16) rotate(-45)");
+
+    var ya = d3.svg.axis()
+      .orient("left")
+      .scale(d3.scale.linear()
+        .domain(height.domain())
+        .range([bottom, top]))
+      .tickValues(height.domain());
+    ya.tickFormat(formatCommas);
+    yAxis.call(ya)
+      .attr("transform", "translate(" + [left - 2, 0] + ")");
+
+    histogramUpdated = true;
   }
 
   function updateHourlyWages(stats, domain) {

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -24,10 +24,6 @@
     position: relative;
   }
 
-  #permalink {
-    float: right;
-  }
-
   #price {
     width: 8em;
   }
@@ -71,11 +67,8 @@
       <div class="six columns">
         <input id="labor_category" name="q" placeholder="Type a labor category" class="search u-full-width" type="text">
       </div>
-      <div class="two columns">
-        <button class="submit button-primary u-full-width">Search</button>
-      </div>
-      <div class="four columns">
-        <a id="permalink" class="button">&infin; permalink</a>
+      <div class="six columns">
+        <button class="submit button-primary">Search</button>
       </div>
     </div>
 
@@ -223,7 +216,6 @@
       inputs = form.selectAll("*[name]"),
       formatPrice = d3.format(",.02f"),
       formatCommas = d3.format(","),
-      permalink = d3.select("#permalink"),
       api = new hourglass.API(),
       $search = $("#labor_category"),
       resultsTable = d3.select("#results-table")
@@ -327,7 +319,6 @@
 
     if (pushState) {
       var href = "?" + hourglass.qs.format(data)
-      permalink.attr("href", href);
       history.pushState(null, null, href);
     }
   }

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -154,6 +154,12 @@
 
       <div class="graphs six columns">
         <h5>Price Stats</h5>
+
+        <div class="loading-indicator">
+          <p class="message">Loading results...</p>
+          <div class="error"></div>
+        </div>
+
         <div class="graph">
           <div id="price-range" class="range-graph has-data">
             <span class="tick min left">
@@ -167,6 +173,7 @@
               $<b class="value"></b>
             </span>
           </div>
+
         </div>
 
         <!--
@@ -215,6 +222,7 @@
       $search = $("#labor_category"),
       resultsTable = d3.select("#results-table")
         .style("display", "none"),
+      loadingIndicator = form.select(".loading-indicator"),
       request;
 
   form.on("submit", function onsubmit() {
@@ -304,6 +312,10 @@
 
     if (error) {
       form.classed("error", true);
+
+      loadingIndicator.select(".error")
+        .text(error.responseText);
+
       // ignore aborts
       if (error.statusText === "abort") {
         return;

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django==1.7.1
 djangorestframework==3.0.2
 -e git+https://github.com/djangonauts/djorm-ext-pgfulltext.git#egg=djorm_ext_pgfulltext-master
 psycopg2==2.5.4
+numpy==1.9.1


### PR DESCRIPTION
Introducing the wage histogram!

![image](https://cloud.githubusercontent.com/assets/113896/5623174/a8732bd0-9503-11e4-89af-99fe31f5c525.png)

This comes courtesy of a new `/api/rates/` query parameter, `?histogram=x`. When specified, a `wage_histogram` array of `x` length is added onto the results object, and it looks like this:

```js
    "wage_histogram": [
        {
            "count": 42, 
            "max": 53.408000000000001, 
            "min": 20.809999999999999
        }, 
        // ...
        {
            "count": 1, 
            "max": 346.79000000000002, 
            "min": 314.19200000000001
        }
    ]
```

This needs to be tested. I've got a simple doctest in [api.views#get_histogram()](https://github.com/shawnbot/hourglass/commit/11167009e985f9cf323f0916df40869e25d2376c#diff-265524153427c5c3f0dd9ae087f16a4bR68), and the visual output looks right, but there are some edge cases to watch out for. In order for the visual histogram to be accurate, we should assert that:

1. `wage_histogram[0].min == minimum` and 
1. `wage_histogram[-1].max == maximum`

On the front-end, we're creating a histogram graph from this array in which the min is a bar's left edge, the max is its right edge, and its height corresponds to the count. Each bar should have a title when you mouse over it that lists the count, min and max.

I've commented out the simple range display because this graph provides all of the same information.