### PR TITLE
Collapsible table columns

### DIFF
--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -427,8 +427,13 @@
     td.enter().append("td")
       .attr("class", function(column) {
         return "column-" + column.key;
+      })
+      .classed("collapsed", function(d) {
+        return d.column.collapsed;
       });
-    td.text(function(d) { return d.string; });
+    td.text(function(d) {
+      return d.column.collapsed ? "" : d.string;
+    });
   }
 
   function getFormData() {
@@ -462,20 +467,22 @@
   function setupColumnHeader(headers) {
     headers
       .datum(function() {
-        var sortable = this.classList.contains("sortable");
         return {
           key: this.getAttribute("data-key"),
           format: getFormat(this.getAttribute("data-format")),
-          sortable: sortable
+          sortable: this.classList.contains("sortable"),
+          collapsible: this.classList.contains("collapsible")
         };
       })
       .each(function(d) {
         this.classList.add("column-" + d.key);
-      })
-      .filter(function(d) {
-        return d.sortable;
-      })
+      });
+
+    headers.filter(function(d) { return d.sortable; })
       .call(setupSortHeader);
+
+    headers.filter(function(d) { return d.collapsible; })
+      .call(setupCollabsibleHeader);
   }
 
   function setupSortHeader(headers) {
@@ -505,6 +512,37 @@
         .classed("sorted", function(c) { return c.sorted; })
         .classed("descending", function(c) { return c.sorted && c.descending; });
       submit(true);
+    }
+  }
+
+  function setupCollabsibleHeader(headers) {
+    headers
+      .each(function(d) {
+        d.collapsed = this.classList.contains("collapsed");
+        d.label = this.innerText;
+      })
+      .on("click", function(d) {
+        d.collapsed = !d.collapsed;
+        updateCollapsed.apply(this, arguments);
+      })
+      .each(updateCollapsed);
+
+    function updateCollapsed(d) {
+      var title = [
+        (d.collapsed ? "Show" : "Hide"),
+        d.label
+      ].join(" ");
+
+      d3.select(this)
+        .classed("collapsed", d.collapsed)
+        .attr("title", title)
+        .text(d.collapsed ? "" : d.label);
+
+      resultsTable.selectAll("td.column-" + d.key)
+        .classed("collapsed", d.collapsed)
+        .text(d.collapsed
+          ? ""
+          : function(d) { return d.string; });
     }
   }
 

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -497,18 +497,13 @@
       if (d.sorted) {
         d.descending = !d.descending;
       }
-
       d.sorted = true;
-
-      console.log("sort:", d);
 
       var sort = (d.descending ? "-" : "") + d.key;
       setFormData({sort: sort});
-
       headers
         .classed("sorted", function(c) { return c.sorted; })
         .classed("descending", function(c) { return c.sorted && c.descending; });
-
       submit(true);
     }
   }

--- a/hourglass_site/static/hourglass_site/style/main.css
+++ b/hourglass_site/static/hourglass_site/style/main.css
@@ -50,8 +50,8 @@ th.sorted {
   position: relative;
 }
 
-  th.sorted:after {
-    content: "▼";
+  th.sorted:after,
+  th.collapsible:after {
     display: inline-block;
     line-height: 1em;
     height: 1em;
@@ -62,9 +62,38 @@ th.sorted {
     margin-right: .25em;
   }
 
+  th.sorted:after {
+    content: "▼";
+  }
+
   th.sorted.descending:after {
     content: "▲";
   }
+
+th.collapsible {
+  text-decoration: underline;
+  cursor: pointer;
+  position: relative;
+}
+
+  th.collapsible:after {
+    content: "▶";
+  }
+
+  th.collapsible.collapsed:after {
+    content: "◀";
+  }
+
+th.collapsed,
+td.collapsed {
+  width: 1.5em !important;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+td.collapsed {
+  border-left: 1px dotted #E1E1E1;
+}
 
 .autocomplete-suggestions {
   position: absolute;

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -48,7 +48,8 @@
   th.column-min_years_experience {  width: 10%; }
   th.column-wage {                  width:  8%; }
   th.column-idv_piid {              width: 12%; }
-  th.column-vendor_name {           width: 35%; }
+  th.column-vendor_name {           width: 25%; }
+  th.column-schedule {              width: 10%; }
 
   td.column-idv_piid {
     white-space: nowrap;
@@ -200,7 +201,7 @@
           <th class="sortable" data-key="current_price" data-format="$%,.02f">Price</th>
           <th data-key="idv_piid">Contract #</th>
           <th data-key="vendor_name">Vendor</th>
-          <th class="sortable collapsible" data-key="schedule">Schedule</th>
+          <th class="sortable collapsible collapsed" data-key="schedule">Schedule</th>
         </tr>
       </thead>
       <tbody>

--- a/selenium_tests/tests.py
+++ b/selenium_tests/tests.py
@@ -72,17 +72,35 @@ class FunctionalTests(LiveServerTestCase):
         labor_cell = driver.find_element_by_css_selector('tbody tr .column-labor_category')
         self.assertTrue('Engineer' in labor_cell.text, 'Labor category cell text mismatch')
 
-    def test_price_filter(self):
+    def test_price_gt(self):
         driver = self.load()
         form = self.get_form()
-        set_form_value(form, 'price__gt', 100)
+        self.search_for('Contractor')
+
+        minimum = 100
+        set_form_value(form, 'price__gt', minimum)
         self.submit_form()
-        self.assertTrue('price__gt=100' in driver.current_url, 'Missing "price__gt=100" in query string')
+        self.assertTrue(('price__gt=%d' % minimum) in driver.current_url, 'Missing "price__gt=%d" in query string' % minimum)
         wait_for(self.data_is_loaded)
 
-        price_cell = driver.find_element_by_css_selector('tbody tr .column-current_price')
-        dollars = float(price_cell.text[1:])
-        self.assertTrue(dollars > 100, 'Minimum price mismatch')
+        for cell in driver.find_elements_by_css_selector('tbody tr .column-current_price'):
+            dollars = float(cell.text[1:])
+            self.assertTrue(dollars > minimum, '%s <= %d' % (cell.text, minimum))
+
+    def test_price_lt(self):
+        driver = self.load()
+        form = self.get_form()
+        self.search_for('Contractor')
+
+        maximum = 200
+        set_form_value(form, 'price__lt', maximum)
+        self.submit_form()
+        self.assertTrue(('price__lt=%d' % maximum) in driver.current_url, 'Missing "price__lt=%d" in query string' % maximum)
+        wait_for(self.data_is_loaded)
+
+        for cell in driver.find_elements_by_css_selector('tbody tr .column-current_price'):
+            dollars = float(cell.text[1:])
+            self.assertTrue(dollars < maximum, '%s >= %d' % (cell.text, maximum))
 
     def test_sort_columns(self):
         driver = self.load()


### PR DESCRIPTION
Introducing collapsible table columns. Activating these is as simple as adding the `collapsible` class to any of the `#results-table th` elements in the index template. I've done so with the [schedule column](https://trello.com/c/GwHnSAu5/40-show-or-make-available-schedule-name-in-results), and have tested it with other columns as well. Collapsing a column hides both the `th` element's text *and* the corresponding `td` elements' text. This was necessary because laying out HTML tables is tricky when there's text in all of the columns, and there wasn't an easy way to "collapse" the cells containing lots of text in CSS alone. A collapsed column looks like this (on the far right):

![image](https://cloud.githubusercontent.com/assets/113896/5670265/36fe349a-9733-11e4-9238-8108abf7d595.png)

There's a `title` attribute on the ◀ icon that reads "Show Schedule" and switches to "Hide Schedule" when you click it:

![image](https://cloud.githubusercontent.com/assets/113896/5670279/6134422c-9733-11e4-8bec-6888485f0ef8.png)

Sorry about the duplicate commits here... I messed things up with `git pull --rebase 18f master` after pushing to my fork, but the changes look legit.