### PR TITLE
Selenium test improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+static/
 *.pyc
 local_settings.py
 *.swp


### PR DESCRIPTION
- No longer hardcoding the dev server, using live_server_url instead
- Generate test data
- Rewrite some tests to take advantage of known test data
- Should be invoked with something like:
    ./manage.py test --liveserver=localhost:8081-8181
- Eliminate asserts that are redundant w/ API tests
- Set longMessage so that built-in failure messages show alongside
  custom ones