### PR TITLE
Allow columns to be sortable and collapsible

### DIFF
--- a/hourglass_site/static/hourglass_site/style/main.css
+++ b/hourglass_site/static/hourglass_site/style/main.css
@@ -104,7 +104,7 @@ th.collapsible a.toggle-collapse {
   line-height: 1.2em;
   padding: 4px;
   text-transform: uppercase;
-  color: #666;
+  color: #999;
   top: 0;
   left: 100%;
   width: 3em;
@@ -115,16 +115,6 @@ th.collapsed,
 td.collapsed {
   width: 1.5em !important;
   border-left: 1px dotted #E1E1E1;
-}
-
-th.collapsible a.toggle-collapse:before {
-  content: "▶";
-  display: inline;
-  margin-right: .5em;
-}
-
-th.collapsible.collapsed a.toggle-collapse:before {
-  content: "◀";
 }
 
 .autocomplete-suggestions {

--- a/hourglass_site/static/hourglass_site/style/main.css
+++ b/hourglass_site/static/hourglass_site/style/main.css
@@ -102,8 +102,9 @@ th.collapsible a.toggle-collapse {
   position: absolute;
   font-size: 1rem;
   line-height: 1.2em;
-  padding: 4px;
+  padding: 2px 4px;
   text-transform: uppercase;
+  text-decoration: underline;
   color: #999;
   top: 0;
   left: 100%;


### PR DESCRIPTION
The Schedule column is now sortable and collapsible, resolving #44:

![hourglass-collapse-fix](https://cloud.githubusercontent.com/assets/113896/5781151/23083296-9d65-11e4-93d4-9ed23c0d57e5.gif)

@brethauer, should I ditch the little left/right triangle in the "show/shide" text and nudge it left by a couple of px, per your sketch?

![hide](https://cloud.githubusercontent.com/assets/7635133/5760081/3a75e0d8-9ca0-11e4-8b90-14307dea9deb.png)

Also seems like it needs some `text-decoration: underline` and a lighter color, huh?