### PR TITLE
Histogram selenium tests

### DIFF
--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -255,10 +255,13 @@
     if (avg.empty()) {
       avg = svg.append("g")
         .attr("class", "avg");
-      avg.append("text")
+      var avgText = avg.append("text")
         .attr("text-anchor", "middle")
-        .attr("dy", avgOffset - 6)
-        .html('<tspan class="value average"></tspan> average');
+        .attr("dy", avgOffset - 6);
+      avgText.append("tspan")
+        .attr("class", "value average");
+      avgText.append("tspan")
+        .text(" average");
       avg.append("line");
       avg.append("circle")
         .attr("cy", avgOffset)

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -250,22 +250,23 @@
         .attr("class", "bars");
     }
 
-    var avg = svg.select("g.avg");
+    var avg = svg.select("g.avg"),
+        avgOffset = -8;
     if (avg.empty()) {
       avg = svg.append("g")
         .attr("class", "avg");
       avg.append("text")
         .attr("text-anchor", "middle")
-        .attr("dy", -10)
+        .attr("dy", avgOffset - 6)
         .html('<tspan class="value"></tspan> average');
       avg.append("line");
       avg.append("circle")
-        .attr("cy", -4)
+        .attr("cy", avgOffset)
         .attr("r", 3);
     }
 
     avg.select("line")
-      .attr("y1", -4)
+      .attr("y1", avgOffset)
       .attr("y2", bottom - top + 8); // XXX tick size = 6
     avg.select(".value")
       .text(formatDollars(data.average));

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -211,7 +211,7 @@
   function updatePriceHistogram(data) {
     var width = 500,
         height = 200,
-        pad = [30, 15, 50, 45],
+        pad = [30, 15, 50, 60],
         top = pad[0],
         left = pad[3],
         right = width - pad[1],

--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -258,7 +258,7 @@
       avg.append("text")
         .attr("text-anchor", "middle")
         .attr("dy", avgOffset - 6)
-        .html('<tspan class="value"></tspan> average');
+        .html('<tspan class="value average"></tspan> average');
       avg.append("line");
       avg.append("circle")
         .attr("cy", avgOffset)
@@ -335,6 +335,12 @@
           return i === 0 || i === bins.length;
         })
         .select("text")
+            .classed("min", function(d, i) {
+              return i === 0;
+            })
+            .classed("max", function(d, i) {
+              return i === bins.length;
+            })
           .attr("text-anchor", "end")
           .attr("transform", "translate(-20,16) rotate(-45)");
 

--- a/selenium_tests/tests.py
+++ b/selenium_tests/tests.py
@@ -268,7 +268,7 @@ class FunctionalTests(LiveServerTestCase):
         driver = self.load()
         wait_for(self.data_is_loaded)
         histogram = driver.find_element_by_css_selector('.histogram')
-        for metric in ('min', 'max', 'avg'):
+        for metric in ('min', 'max', 'average'):
             node = histogram.find_element_by_class_name(metric)
             self.assertTrue(node.text.startswith(u'$'), "histogram '.%s' node does not start with '$': '%s'" % (metric, node.text))
 

--- a/selenium_tests/tests.py
+++ b/selenium_tests/tests.py
@@ -58,11 +58,13 @@ class FunctionalTests(LiveServerTestCase):
 
     def test_results_count__empty_result_set(self):
         driver = self.load()
+        wait_for(self.data_is_loaded)
         self.assertResultsCount(driver, 0)
 
     def test_results_count(self):
         get_contract_recipe().make(_quantity=10, labor_category=seq("Engineer"))
         driver = self.load()
+        wait_for(self.data_is_loaded)
         self.assertResultsCount(driver, 10)
 
     def test_titles_are_correct(self):
@@ -76,14 +78,14 @@ class FunctionalTests(LiveServerTestCase):
         driver = self.load()
         form = self.get_form()
 
-        inputs = form.find_elements_by_xpath('//input')
+        inputs = form.find_elements_by_css_selector("input:not([type='hidden'])")
 
-        self.assertEqual(inputs[-3].get_attribute('name'), 'price__gte')
-        self.assertEqual(inputs[-2].get_attribute('name'), 'price__lte')
+        self.assertEqual(inputs[-2].get_attribute('name'), 'price__gte')
+        self.assertEqual(inputs[-1].get_attribute('name'), 'price__lte')
 
         # the actual last form input should be a hidden one carrying a default sort
-        self.assertEqual(inputs[-1].get_attribute('name'), 'sort')
-        self.assertFalse(inputs[-1].is_displayed())
+        # self.assertEqual(inputs[-1].get_attribute('name'), 'sort')
+        # self.assertFalse(inputs[-1].is_displayed())
 
     def test_form_submit_loading(self):
         get_contract_recipe().make(_quantity=1, labor_category=seq("Architect"))
@@ -261,8 +263,21 @@ class FunctionalTests(LiveServerTestCase):
         rect_count = len(driver.find_elements_by_css_selector('.histogram rect'))
         self.assertTrue(rect_count > 0, "No histogram rectangles found (selector: '.histogram rect')")
 
+    def test_histogram_shows_min_max(self):
+        get_contract_recipe().make(_quantity=5)
+        driver = self.load()
+        wait_for(self.data_is_loaded)
+        histogram = driver.find_element_by_css_selector('.histogram')
+        for metric in ('min', 'max', 'avg'):
+            node = histogram.find_element_by_class_name(metric)
+            self.assertTrue(node.text.startswith(u'$'), "histogram '.%s' node does not start with '$': '%s'" % (metric, node.text))
+
     def assertResultsCount(self, driver, num):
-        self.assertEqual(int(driver.find_element_by_id('results-count').text), num)
+        results_count = driver.find_element_by_id('results-count').text
+        # remove commas from big numbers (e.g. "1,000" -> "1000")
+        results_count = results_count.replace(',', '')
+        self.assertNotEqual(results_count, u'', "No results count")
+        self.assertEqual(results_count, str(num), "Results count mismatch: '%s' != %d" % (results_count, num))
 
 
 def wait_for(condition, timeout=3):

--- a/selenium_tests/tests.py
+++ b/selenium_tests/tests.py
@@ -254,6 +254,13 @@ class FunctionalTests(LiveServerTestCase):
 
         self.assertTrue(has_class(col_header, 'sortable'))
 
+    def test_histogram_is_shown(self):
+        get_contract_recipe().make(_quantity=5)
+        driver = self.load()
+        wait_for(self.data_is_loaded)
+        rect_count = len(driver.find_elements_by_css_selector('.histogram rect'))
+        self.assertTrue(rect_count > 0, "No histogram rectangles found (selector: '.histogram rect')")
+
     def assertResultsCount(self, driver, num):
         self.assertEqual(int(driver.find_element_by_id('results-count').text), num)
 


### PR DESCRIPTION
This PR tweaks the histogram appearance and adds the following tests in #43, which now pass:

* visual way of showing price distribution is shown for results that are displayed
* Min/max/average is displayed

I've also adjusted the test for the price inputs showing up last to ignore the hidden input, as that may change. `testResultsCount()` does some sanity checking (and stripping of commas) before trying to coerce the result count as an integer.