### PR TITLE
Fix padding-right in table cells

### DIFF
--- a/hourglass_site/static/hourglass_site/style/main.css
+++ b/hourglass_site/static/hourglass_site/style/main.css
@@ -14,8 +14,8 @@ table {
   width: 100%;
 }
 
-td, td:first-child,
-th, th:first-child,
+td, td:first-child, td:last-child,
+th, th:first-child, th:last-child,
 table caption {
   position: relative;
   padding: .25em .5em;


### PR DESCRIPTION
When you sort by Schedule ascending, you can see that the last cell of each row in the results table has no right padding. This fixes that.