### PR TITLE
Preserved order_by precedence when there are multiple params

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -132,21 +132,21 @@ class ContractsTest(TestCase):
            'business_size': None}])
 
     def test_filter_by_min_education(self):
-        self.make_test_set()
-        resp = self.c.get(self.path, {'min_education': 'MA'})
+        get_contract_recipe().make(_quantity=5, education_level=cycle(['MA', 'HS', 'BA', 'AA', 'PHD']))
+        resp = self.c.get(self.path, {'min_education': 'AA', 'sort': 'education_level'})
         self.assertEqual(resp.status_code, 200)
 
-        self.assertResultsEqual(resp.data['results'],
-         [{'idv_piid': 'ABC234',
-           'vendor_name': 'Numbers R Us',
-           'labor_category': 'Accounting, CPA',
-           'education_level': 'Masters',
-           'min_years_experience': 5,
-           'hourly_rate_year1': 50.0,
-           'current_price': 50.0,
-           'schedule': None,
-           'contractor_site': None,
-           'business_size': None}])
+        # if this is working properly, it does not include HS in the results
+        self.assertResultsEqual(resp.data['results'], [
+            {  'idv_piid': 'ABC1234',
+               'education_level': 'Associates' },
+            {  'idv_piid': 'ABC1233',
+               'education_level': 'Bachelors' },
+            {  'idv_piid': 'ABC1231',
+               'education_level': 'Masters' },
+            {  'idv_piid': 'ABC1235',
+               'education_level': 'Ph.D.' },
+           ], True)
 
     def test_sort_by_education_level(self):
         # deliberately placing education level cycle out of order so that proper ordering cannot be

--- a/contracts/models.py
+++ b/contracts/models.py
@@ -36,25 +36,17 @@ class ContractsQuerySet(SearchQuerySet):
 
         edu_index = None
 
-        if 'education_level' in args:
-            edu_index = args.index('education_level')
-        elif '-education_level' in args:
-            edu_index = args.index('-education_level')
+        sort_params = list(args)
+
+        if 'education_level' in sort_params:
+            edu_index = sort_params.index('education_level')
+        elif '-education_level' in sort_params:
+            edu_index = sort_params.index('-education_level')
 
         if edu_index is not None:
-            first_ordering, last_ordering = args[:edu_index], args[edu_index+1:]
-            param = args[edu_index].replace('education_level', 'edu_sort')
-
-            queryset = super(ContractsQuerySet, self)
-
-            if first_ordering:
-                queryset = queryset.order_by(first_ordering)
-
-            queryset = queryset.extra(select={'edu_sort': edu_sort_sql}, order_by=[param])
-
-            if last_ordering:
-                queryset = queryset.order_by(last_ordering)
-
+            sort_params[edu_index] = 'edu_sort' if not args[edu_index].startswith('-') else '-edu_sort'
+            queryset = super(ContractsQuerySet, self)\
+                .extra(select={'edu_sort': edu_sort_sql}, order_by=sort_params)
         else:
             queryset = super(ContractsQuerySet, self)\
                 .order_by(*args, **kwargs)


### PR DESCRIPTION
- Refactored all order_by()s into a single extra(), since Django deliberately
discards all but the last order_by
- Tests now allow checking just a subset of expected keys against results-- more concise tests!