### PR TITLE
Query type tweaks

### DIFF
--- a/hourglass_site/static/hourglass_site/js/index.js
+++ b/hourglass_site/static/hourglass_site/js/index.js
@@ -19,11 +19,16 @@
     submit(true);
   });
 
-  form.on("reset", function onsubmit() {
+  form.on("reset", function onreset() {
     // XXX we shouldn't have to do this...
     // shouldn't a reset input clear them?
     inputs.each(function() {
-      // FIXME: if this.type === "checkbox", toggle this.checked
+      switch (this.type) {
+        case 'checkbox':
+        case 'radio':
+          this.checked = this.hasAttribute('checked');
+          return;
+      }
       this.value = "";
     });
     submit(true);
@@ -485,7 +490,10 @@
       switch (this.type) {
         case "radio":
         case "checkbox":
-          if (!this.checked) return;
+          // bail if it's not checked *or* it was checked by default,
+          if (!this.checked || this.hasAttribute("checked")) {
+            return;
+          }
           break;
       }
       data[this.name] = this.value;

--- a/hourglass_site/templates/index.html
+++ b/hourglass_site/templates/index.html
@@ -20,8 +20,8 @@
         </div>
       </div>
       <div class="six columns">
-        <button id="submit" class="submit button-primary">Search</button>
-        <input id="reset" class="reset button" type="reset" value="Clear search">
+        <button id="submit-button" class="submit button-primary">Search</button>
+        <input id="reset-button" class="reset button" type="reset" value="Clear search">
       </div>
     </div>
 


### PR DESCRIPTION
This is a fix for #82 that also renames the submit and reset buttons so that we don't override the form DOM object's `submit()` and `reset()` methods.